### PR TITLE
Update plugin censure (v2) (beaucoup trop sensible)

### DIFF
--- a/src/jvc/src/plugin/AntiCensorPlugin.js
+++ b/src/jvc/src/plugin/AntiCensorPlugin.js
@@ -57,7 +57,7 @@ export class AntiCensorPlugin {
                 for (const key in AntiCensorPlugin.associations) {
                     const value = AntiCensorPlugin.associations[key];
                     const [from, to] = [key, value];
-                    const regex = new RegExp(from, 'gi');
+                    const regex = new RegExp(`\\b${from}[.,;!?()'"-]?\\b`, 'gi');
                     messageInput.value = messageInput.value.replace(regex, to);
                 }
             });


### PR DESCRIPTION
**Là** je me suis me suis pas planté ^^

Bonjour, alors déjà, je ne suis pas expert donc je ne sais pas si c'est la bonne approche, mais c'est pour éviter ce que beaucoup de membres m'ont reporté une prise en charge beaucoup trop hâtive, surtout en message privé du Plugin concerné

Typiquement, ce n'est pas sensible aux espaces, du coup, on peut se retrouver avec ça remplacé :

update => **uhumain bien eduquée** (actuellement) => Le Plugin actuel est beaucoup trop intrusif.

J'ai essayé de faire une regex peut-être qu'elle est trop complexe pour ce que c'est, peut-être que j'aurais dû mettre des espaces au mot par mot.

Mais voilà, je propose un commit et en même temps, c'est aussi une issue.

Car les mots qui sont pris en charge, **même** sans espace => ça aboutit parfois à n'importe quoi ^^