### PR TITLE
 Double intégration (choix intégration bas haut) cette fois c'est bon

### DIFF
--- a/src/jvc/src/ScriptOptions.js
+++ b/src/jvc/src/ScriptOptions.js
@@ -51,7 +51,8 @@ class ScriptOptions {
             name: 'embedType',
             type: 'select',
             values: [
-                { value: 'iframe', 'label': 'intégré' },
+                { value: 'iframe', 'label': 'intégré (Haut)' },
+                { value: 'iframe-bottom', 'label': 'intégré (Bas)' },
                 { value: 'overlay', 'label': 'overlay' },
             ],
             label: 'Mode d\'intégration',
@@ -70,7 +71,7 @@ class ScriptOptions {
             label: 'Hauteur fenêtre mode intégré',
             description: `Choisir la taille de la zone de contenu dans l\'interface RisiBank (mode intégré)`,
             default: () => '165px',
-            activateIf: options => options.embedType === 'iframe',
+            activateIf: options => ['iframe', 'iframe-bottom'].includes(options.embedType),
         },
         {
             name: 'mediaSize',

--- a/src/jvc/src/component/RisiBankJVC.js
+++ b/src/jvc/src/component/RisiBankJVC.js
@@ -12,10 +12,12 @@ import { RemoveDisclaimerPlugin } from '../plugin/RemoveDisclaimerPlugin.js';
 import { YoutubePlugin } from '../plugin/YoutubePlugin.js';
 import { OptionsPanel } from './OptionsPanel.js';
 
-
 /**
  * Main class to control the RisiBank JVC userscript
  */
+
+const embedIframeModes = ['iframe', 'iframe-bottom'];
+
 export class RisiBankJVC {
 
     constructor() {
@@ -128,7 +130,11 @@ class RisiBankJVCView {
             toCleanEl.remove();
         }
 
-        this.afterIntegrationSelector = '.messageEditor__edit';
+        if (scriptOptions.getOption('embedType') === 'iframe-bottom') {
+            this.afterIntegrationSelector = '.messageEditor__buttonEdit';
+        } else {
+            this.afterIntegrationSelector = '.messageEditor__edit';
+        }
         this.textAreaSelector = '.messageEditor__edit';
 
         // Globals
@@ -136,7 +142,7 @@ class RisiBankJVCView {
 
         // Prepare the location where the RisiBank embed will be integrated
         // Only add the iframe container if integration mode is iframe
-        if ((scriptOptions.getOption('embedType') === 'iframe') && (scriptOptions.getOption('enabled'))) {
+        if (embedIframeModes.includes(scriptOptions.getOption('embedType')) && scriptOptions.getOption('enabled')) {
             try {
                 const afterIntegrationEl = document.querySelector(this.afterIntegrationSelector);
                 const div = document.createElement('div');
@@ -185,7 +191,7 @@ class RisiBankJVCView {
         this.mount();
 
         // Start embed if iframe mode
-        if ((scriptOptions.getOption('embedType')) === 'iframe' && (scriptOptions.getOption('enabled'))) {
+        if (embedIframeModes.includes(scriptOptions.getOption('embedType')) && scriptOptions.getOption('enabled')) {
             this.startEmbed();
         }
 
@@ -285,7 +291,7 @@ class RisiBankJVCController {
         // RisiBank button to toggle plugin
         const toggleRisiBankButtons = Array.from(document.querySelectorAll('.risibank-toggle'));
         for (const toggleRisiBankButton of toggleRisiBankButtons) {
-            if ((scriptOptions.getOption('embedType')) === 'iframe') {
+            if (embedIframeModes.includes(scriptOptions.getOption('embedType'))) {
                 toggleRisiBankButton.addEventListener('click', async () => {
                     await scriptOptions.saveOption('enabled', ! (scriptOptions.getOption('enabled')));
                     this.view.init();

--- a/src/jvc/src/component/RisiBankJVC.js
+++ b/src/jvc/src/component/RisiBankJVC.js
@@ -149,7 +149,11 @@ class RisiBankJVCView {
                 div.id = this.iframeContainerId;
                 div.classList.add('risibank-cleanup');
                 div.style.height = scriptOptions.getOption('embeddedContainerHeight');
-                afterIntegrationEl.parentElement.insertBefore(div, afterIntegrationEl);
+                if (scriptOptions.getOption('embedType') === 'iframe-bottom') {
+                    afterIntegrationEl.parentElement.appendChild(div);
+                } else {
+                    afterIntegrationEl.parentElement.insertBefore(div, afterIntegrationEl);
+                }
             } catch (error) {
                 console.warn('Unable to prepare location for the RisiBank embed', error);
             }


### PR DESCRIPTION
@7PH Désolé j'ai fait 3 tests j'étais persuadé d'y arriver Je suis désolé du spam j'ai réussi à l'injecter en bas mais j'avais aucun point d'approche à partir du bas donc j'ai dû mettre 2 redondances de conditionnel le problème c'est qu'il y a beaucoup moins de cadres et j'ai pas trouvé d'autre approche si jamais je veux mettre vraiment la banque tout en bas

Et niveau UX pour l'avoir essayé **à part dans le chat** l'avoir en bas c'est le bonheur.

https://github.com/Lantea-Git/Userscripts_Test/raw/refs/heads/main/jvc3.user.js compile vers le bas 
**Mais cette version a de la redondance car j'ai pas trouvé d'éléments à cibler en dessous des boutons**


Sinon il y a plus simple mais je trouve qu'on perd l'intérêt l'intérêt en dehors du chat c'est d'avoir en bas
https://github.com/RisiBank/risibank-userscripts/pull/12
https://github.com/Lantea-Git/Userscripts_Test/raw/refs/heads/main/jvc.user.js

Les 2 versions sont compilées Tu peux les essayer Ma première est la préférée mais il y a de la redondance Si t'arrives à simplifier.

Et vraiment niveau UX C'est super intéressant je te laisse cette PR ouverte

