### PR TITLE
Move regex-escaped RISIBANK_URL to config for reusability

### DIFF
--- a/src/jvc/src/config.js
+++ b/src/jvc/src/config.js
@@ -3,3 +3,6 @@
 //   export const RISIBANK_URL = 'https://risibank.fr';
 // Use a bare origin (scheme + host + port), no trailing slash.
 export const RISIBANK_URL = 'https://risibank.fr';
+
+// RISIBANK_URL escaped for safe use inside a RegExp (special chars like '.' are backslash-escaped).
+export const RISIBANK_URL_ESCAPED = RISIBANK_URL.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');

--- a/src/jvc/src/plugin/LinkEnhancerPlugin.js
+++ b/src/jvc/src/plugin/LinkEnhancerPlugin.js
@@ -1,4 +1,4 @@
-import { RISIBANK_URL } from '../config.js';
+import { RISIBANK_URL, RISIBANK_URL_ESCAPED } from '../config.js';
 
 
 export class LinkEnhancerPlugin {
@@ -10,8 +10,7 @@ export class LinkEnhancerPlugin {
     async install() {
         // Find all potential links to RisiBank images
         let links = Array.from(document.querySelectorAll('a.xXx'));
-        // RisiBank origin, escaped for safe use inside a RegExp
-        const base = RISIBANK_URL.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+        const base = RISIBANK_URL_ESCAPED;
         // Normalize links pointing to different risibank resources to pointing to the full URL
         const replaceRegExps = {
             [`^${base}/cache/medias/([\\d/]+)/([\\d]+)/(\\w+)\\.(\\w+)$`]: `${RISIBANK_URL}/media/$2-media-$4`,


### PR DESCRIPTION
Export RISIBANK_URL_ESCAPED directly from config.js so it can be reused across plugins without duplicating the escaping logic.