### PR TITLE
fix: wait for React toolbar hydration before mounting

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "risibank-userscripts",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "risibank-userscripts",
-      "version": "1.4.1",
+      "version": "1.4.2",
       "license": "ISC",
       "dependencies": {
         "risibank-web-api": "^1.2.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "risibank-userscripts",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "description": "Enhance RisiBank integration on various places using userscipts ✨",
   "main": "src/index.js",
   "scripts": {

--- a/src/jvc/head.txt
+++ b/src/jvc/head.txt
@@ -3,7 +3,7 @@
 // @namespace    risibank.fr
 // @description  La RisiBank intégrée sur JVC, comme par magie !
 // @author       RisiBank Admin
-// @version      1.4.1
+// @version      1.4.2
 // @website      https://risibank.fr
 // @homepage     https://risibank.fr
 // @match        https://www.jeuxvideo.com/forums/*

--- a/src/jvc/index.js
+++ b/src/jvc/index.js
@@ -12,8 +12,8 @@ async function init () {
 
     window.addEventListener('load', async event => {
 
-        // Wait for the body element to be available
-        await waitForFunction(() => document.body);
+        // Wait for React to hydrate the editor toolbar before mounting
+        await waitForFunction(() => document.querySelector('.buttonsEditor'), 10000);
 
         // Start add-on
         new RisiBankJVC();


### PR DESCRIPTION
## Summary

After JVC's React update, the `.buttonsEditor` toolbar is hydrated asynchronously after the `load` event fires. The existing code polled for `document.body`, which returns immediately (body always exists), so `new RisiBankJVC()` ran before the toolbar was in the DOM and `mount()` silently failed.

- **Before:** `await waitForFunction(() => document.body)`
- **After:** `await waitForFunction(() => document.querySelector('.buttonsEditor'), 10000)`

Polls every 50 ms for up to 10 s for React to inject `.buttonsEditor`. On non-forum pages where the editor never appears, the timeout expires and execution continues as before (silent no-op).

Fixes: #14 (see https://github.com/RisiBank/risibank-userscripts/issues/14#issuecomment-4698250376)

## Test plan
- [ ] Load a JVC forum topic page — RisiBank toolbar button appears in the editor
- [ ] Load a JVC forum topic page on mobile/slow device — button still appears (no race with React hydration)
- [ ] Load a JVC page without an editor (e.g. home page) — no JS errors thrown